### PR TITLE
Remove next tag version for gulp

### DIFF
--- a/packages/generator-frontend/app/index.js
+++ b/packages/generator-frontend/app/index.js
@@ -514,7 +514,7 @@ class PixelGenerator extends Generator {
       '@pixel2html/scripts-frontend',
       'del',
       'fs-path',
-      'gulp@next',
+      'gulp',
       'gulp-zip',
       'yargs',
     ]


### PR DESCRIPTION
Remove next tag version for gulp since it doesn't exist. Fix #11 